### PR TITLE
Less 003 server cleanup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,44 @@
+name: CI
+
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+    branches: ["**"]
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: Pester on ${{ matrix.shell }}
+    runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        shell: [pwsh, powershell]   # PowerShell 7 + Windows PowerShell 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Prepare PowerShell (${{ matrix.shell }})
+        shell: ${{ matrix.shell }}
+        run: |
+          Set-ExecutionPolicy Bypass -Scope Process -Force
+          # Avoid Windows 'sc' alias collision during scripts
+          Remove-Item alias:sc -ErrorAction SilentlyContinue
+
+      - name: Install Pester 5.5+
+        shell: ${{ matrix.shell }}
+        run: |
+          Set-PSRepository -Name PSGallery -InstallationPolicy Trusted
+          if (-not (Get-Module Pester -ListAvailable | Where-Object { $_.Version -ge [Version]'5.5' })) {
+            Install-Module Pester -Scope CurrentUser -Force -SkipPublisherCheck -MinimumVersion 5.5
+          }
+          Import-Module Pester -MinimumVersion 5.5 -Force
+
+      - name: Run tests (Pester CI)
+        shell: ${{ matrix.shell }}
+        run: |
+          Invoke-Pester -Path .\tests -CI

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -9,13 +9,54 @@ on:
 jobs:
   smoke:
     runs-on: windows-latest
+    # give ourselves breathing room; individual steps will fail fast if unhealthy
+    timeout-minutes: 10
+
     steps:
       - uses: actions/checkout@v4
-      - name: Run Smoke.ps1
+
+      - name: Env info
+        shell: pwsh
+        run: |
+          $PSVersionTable
+          Get-Location
+          Get-ChildItem -Path . -Recurse -Depth 2 | Select-Object -First 20 FullName
+
+      - name: Start server (headless)
         shell: pwsh
         run: |
           Set-ExecutionPolicy Bypass -Scope Process -Force
           Remove-Item alias:sc -ErrorAction SilentlyContinue
-          pwsh -NoProfile -ExecutionPolicy Bypass -File .\tools\Run-Server.ps1 -Port 7780 | Out-Null
+          pwsh -NoProfile -ExecutionPolicy Bypass -File .\tools\Run-Server.ps1 -Port 7780 -Debug
+
+      - name: Verify health (127.0.0.1:7780)
+        shell: pwsh
+        run: |
+          $ok=$false
+          foreach($i in 1..20){
+            try{
+              $r = Invoke-WebRequest http://127.0.0.1:7780/ -TimeoutSec 2
+              if($r.StatusCode -eq 200){ $ok=$true; break }
+            }catch{
+              Write-Host "Attempt $i: $($_.Exception.Message)"
+            }
+            Start-Sleep -Seconds 1
+          }
+          if(-not $ok){
+            Write-Host "Listeners on 7780:"
+            try { Get-NetTCPConnection -State Listen | ? LocalPort -eq 7780 | Format-List * } catch {}
+            Write-Host "`nFirst lines of server script (for context):"
+            Get-Content .\MythicCore\scripts\Osirisborn.Server.ps1 -First 60
+            throw "Server did not become healthy"
+          }
+
+      - name: Run Smoke.ps1
+        shell: pwsh
+        run: |
           pwsh -NoProfile -File .\tools\Smoke.ps1 -Port 7780 -AddXP
-          pwsh -NoProfile -File .\tools\Stop-Server.ps1 -Port 7780 | Out-Null
+
+      - name: Stop server
+        if: always()
+        shell: pwsh
+        run: |
+          pwsh -NoProfile -File .\tools\Stop-Server.ps1 -Port 7780; exit 0

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -1,0 +1,21 @@
+name: smoke
+
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+    branches: ["**"]
+
+jobs:
+  smoke:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run Smoke.ps1
+        shell: pwsh
+        run: |
+          Set-ExecutionPolicy Bypass -Scope Process -Force
+          Remove-Item alias:sc -ErrorAction SilentlyContinue
+          pwsh -NoProfile -ExecutionPolicy Bypass -File .\tools\Run-Server.ps1 -Port 7780 | Out-Null
+          pwsh -NoProfile -File .\tools\Smoke.ps1 -Port 7780 -AddXP
+          pwsh -NoProfile -File .\tools\Stop-Server.ps1 -Port 7780 | Out-Null

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -9,7 +9,6 @@ on:
 jobs:
   smoke:
     runs-on: windows-latest
-    # give ourselves breathing room; individual steps will fail fast if unhealthy
     timeout-minutes: 10
 
     steps:
@@ -22,32 +21,51 @@ jobs:
           Get-Location
           Get-ChildItem -Path . -Recurse -Depth 2 | Select-Object -First 20 FullName
 
-      - name: Start server (headless)
+      - name: Start server (inline, capture logs)
+        id: start
         shell: pwsh
         run: |
           Set-ExecutionPolicy Bypass -Scope Process -Force
           Remove-Item alias:sc -ErrorAction SilentlyContinue
-          pwsh -NoProfile -ExecutionPolicy Bypass -File .\tools\Run-Server.ps1 -Port 7780 -Debug
+
+          $repo   = (Resolve-Path ".").Path
+          $server = Join-Path $repo "MythicCore\scripts\Osirisborn.Server.ps1"
+          if (-not (Test-Path $server)) { throw "Server script not found: $server" }
+
+          $log = Join-Path $repo "server.log"
+          $err = Join-Path $repo "server.err.log"
+
+          $p = Start-Process pwsh -WorkingDirectory $repo -NoNewWindow `
+                -ArgumentList @('-NoProfile','-ExecutionPolicy','Bypass','-File', $server) `
+                -RedirectStandardOutput $log -RedirectStandardError $err -PassThru
+
+          "PID=$($p.Id)" | Out-File -FilePath server.pid -Encoding ascii -Force
+          Write-Host "Server PID: $($p.Id)"
+          Write-Host "Logs: $log / $err"
 
       - name: Verify health (127.0.0.1:7780)
         shell: pwsh
         run: |
-          $ok=$false
-          foreach($i in 1..20){
+          $ok = $false
+          foreach($i in 1..40){
             try{
               $r = Invoke-WebRequest http://127.0.0.1:7780/ -TimeoutSec 2
-              if($r.StatusCode -eq 200){ $ok=$true; break }
+              if($r.StatusCode -eq 200){ $ok = $true; break }
             }catch{
-              Write-Host "Attempt $i: $($_.Exception.Message)"
+              # KEY FIX: avoid "$i:" parsing issue by using format string
+              Write-Host ("Attempt {0}: {1}" -f $i, $_.Exception.Message)
             }
-            Start-Sleep -Seconds 1
+            Start-Sleep -Milliseconds 300
           }
+
           if(-not $ok){
-            Write-Host "Listeners on 7780:"
+            Write-Host "`n--- server.log (tail) ---"
+            if(Test-Path .\server.log){ Get-Content .\server.log -Tail 200 }
+            Write-Host "`n--- server.err.log (tail) ---"
+            if(Test-Path .\server.err.log){ Get-Content .\server.err.log -Tail 200 }
+            Write-Host "`n--- Listeners on 7780 ---"
             try { Get-NetTCPConnection -State Listen | ? LocalPort -eq 7780 | Format-List * } catch {}
-            Write-Host "`nFirst lines of server script (for context):"
-            Get-Content .\MythicCore\scripts\Osirisborn.Server.ps1 -First 60
-            throw "Server did not become healthy"
+            throw "Server did not become healthy on 127.0.0.1:7780"
           }
 
       - name: Run Smoke.ps1
@@ -59,4 +77,20 @@ jobs:
         if: always()
         shell: pwsh
         run: |
-          pwsh -NoProfile -File .\tools\Stop-Server.ps1 -Port 7780; exit 0
+          try {
+            if(Test-Path .\server.pid){
+              $pid = Get-Content .\server.pid | ForEach-Object { ($_ -split '=')[1] } | ForEach-Object { [int]$_ }
+              if($pid){ Stop-Process -Id $pid -Force -ErrorAction SilentlyContinue }
+            }
+          } catch {}
+          exit 0
+
+      - name: Upload server logs (on failure)
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: server-logs
+          path: |
+            server.log
+            server.err.log
+            server.pid

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 ![CI](https://github.com/Osirisborn89/osirisborn/actions/workflows/ci.yml/badge.svg)
+![CI](https://github.com/Osirisborn89/osirisborn/actions/workflows/ci.yml/badge.svg)
 # Osirisborn (Proprietary)
 
 **Copyright © 2025 Osirisborn89. All rights reserved.**  
@@ -26,4 +27,5 @@ $cli = Join-Path $env:USERPROFILE 'Osirisborn\MythicCore\scripts\osirisborn.ps1'
 # Dashboard server
 pwsh -NoProfile -ExecutionPolicy Bypass -File "$env:USERPROFILE\Osirisborn\MythicCore\scripts\Osirisborn.Server.ps1"
 # then open http://localhost:7777/
+
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+![CI](https://github.com/Osirisborn89/osirisborn/actions/workflows/ci.yml/badge.svg)
 # Osirisborn (Proprietary)
 
 **Copyright © 2025 Osirisborn89. All rights reserved.**  
@@ -25,3 +26,4 @@ $cli = Join-Path $env:USERPROFILE 'Osirisborn\MythicCore\scripts\osirisborn.ps1'
 # Dashboard server
 pwsh -NoProfile -ExecutionPolicy Bypass -File "$env:USERPROFILE\Osirisborn\MythicCore\scripts\Osirisborn.Server.ps1"
 # then open http://localhost:7777/
+

--- a/tools/Run-Server.ps1
+++ b/tools/Run-Server.ps1
@@ -1,0 +1,41 @@
+param(
+  [int]$Port = 7780,
+  [switch]$Debug
+)
+$ErrorActionPreference = 'SilentlyContinue'
+$repo   = (Resolve-Path ".").Path
+$server = Join-Path $repo "MythicCore\scripts\Osirisborn.Server.ps1"
+
+# Free the port & kill old processes
+Get-NetTCPConnection -LocalPort $Port -State Listen -ErrorAction SilentlyContinue |
+  ForEach-Object { try { Stop-Process -Id $_.OwningProcess -Force } catch {} }
+Get-CimInstance Win32_Process |
+  Where-Object { $_.CommandLine -match 'Osirisborn\.Server\.ps1|Run-MythicCore\.ps1' } |
+  ForEach-Object { try { Stop-Process -Id $_.ProcessId -Force } catch {} }
+
+# Start headless (CI-safe)
+$env:OSIRISBORN_DEBUG = if ($Debug) { '1' } else { '0' }
+$ci = $env:GITHUB_ACTIONS -eq 'true'
+
+# No UI, no -NoExit on CI
+$argList = @('-NoProfile','-ExecutionPolicy','Bypass','-File',"$server")
+if (-not $ci) { $argList = @('-NoExit') + $argList }
+$ws = if ($ci) { 'Hidden' } else { 'Normal' }
+
+$proc = Start-Process pwsh -WorkingDirectory $repo -ArgumentList $argList -WindowStyle $ws -PassThru
+
+# Health gate (slightly longer for CI) against 127.0.0.1
+$ok = $false
+foreach ($i in 1..60) {
+  try {
+    $r = Invoke-WebRequest "http://127.0.0.1:$Port/" -TimeoutSec 2
+    if ($r.StatusCode -eq 200) { $ok = $true; break }
+  } catch {}
+  Start-Sleep -Milliseconds 500
+}
+if (-not $ok) {
+  Write-Error "❌ Server failed health check on port $Port"
+  try { Stop-Process -Id $proc.Id -Force } catch {}
+  exit 1
+}
+"✅ Server healthy on http://127.0.0.1:$Port/ (pid:$($proc.Id))"


### PR DESCRIPTION
## Summary
LESS-003 server cleanup + guardrails:
- Added tools/Run-Server.ps1, Stop-Server.ps1, Smoke.ps1, Precommit.ps1, CI.ps1
- Hardened XP summary (wrapper + V5) and routes
- Pester tests added (tests/XP.Tests.ps1)
- GitHub Actions: CI (Pester on pwsh + powershell) and smoke workflow
- README: CI badge

## How I tested
- `.\tools\CI.ps1 -AddXP` → ALL GREEN locally
- `Invoke-Pester -Path .\tests` → 6/6 passing
- Manual sanity: /, /diag, /xp.json, /xp.debug

## Risks / Notes
- Branch protection requires checks to pass: 
  - CI / Pester on pwsh
  - CI / Pester on powershell
  - smoke / smoke
- Touches server scripts and tests only.