### PR TITLE
add CODEOWNERS to guard portal UI files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+/MythicCore/www/*                   @Osirisborn89
+/tests/Portal.UI.Guard.ps1          @Osirisborn89
+/.github/workflows/portal-guard.yml @Osirisborn89


### PR DESCRIPTION
Adds .github/CODEOWNERS to require @Osirisborn89 review for the portal webroot, the UI guard test, and the guard workflow. This locks the purple standalone portal and prevents accidental regressions. No functional code changes.